### PR TITLE
Require libraries to prevent byte-compilation issues, remove unused hook

### DIFF
--- a/evil-rails.el
+++ b/evil-rails.el
@@ -36,13 +36,14 @@
 ;; evil-rails is Ruby on Rails support fo Evil mode
 
 ;; Code:
+
+(require 'evil)
+(require 'projectile-rails)
+
 (defgroup evil-rails nil
   "Evil Rails customizations."
   :prefix "evil-rails-"
   :group 'evil-rails)
-
-(defvar evil-rails-minor-mode-hook nil
-  "*Hook for customising evil-rails.")
 
 ;; Projectile actions.
 


### PR DESCRIPTION
- Without the "require"s, loading and using this code could fail if the related libraries were not yet loaded
- Nothing would have called the hook, since there's no associated mode definition