### PR TITLE
Add `V` and `S` variants to `:A`

### DIFF
--- a/evil-rails.el
+++ b/evil-rails.el
@@ -48,7 +48,19 @@
 
 ;; Projectile actions.
 
-(evil-ex-define-cmd "A"           'projectile-toggle-between-implementation-and-test)
+(evil-ex-define-cmd "A"  'projectile-toggle-between-implementation-and-test)
+(evil-ex-define-cmd "AV" '(lambda ()
+                            (interactive)
+                            (evil-window-vsplit)
+                            (windmove-right)
+                            (projectile-toggle-between-implementation-and-test)))
+(evil-ex-define-cmd "AS" '(lambda ()
+                            (interactive)
+                            (evil-window-split)
+                            (windmove-down)
+                            (projectile-toggle-between-implementation-and-test)))
+
+
 
 ;; Projectile Rails find actions.
 


### PR DESCRIPTION
[vim-rails](https://github.com/tpope/vim-rails) defines :AS and :AV variants to :A, which open the alternate file in a horizontal and vertical split, respectively.

This patch provides evil-rails with the same behavior using `projectile-toggle-between-implementation-and-test`.